### PR TITLE
Add create UniText MenuItem to GameObject menu

### DIFF
--- a/Editor/UniTextEditorMenu.cs
+++ b/Editor/UniTextEditorMenu.cs
@@ -1,0 +1,47 @@
+using UnityEngine;
+using UnityEditor;
+using System.Reflection;
+namespace LightSide
+{
+    public class UniTextEditorMenu
+    {
+        [MenuItem("GameObject/UI/Text - UniText", false, 1990)]
+        private static void CreateUniTextObject()
+        {
+            if(Selection.gameObjects == null || Selection.gameObjects.Length == 0) 
+            {
+                CreateUniTextObject(null);
+            } 
+            else
+            {
+                foreach (var obj in Selection.gameObjects) {
+                    CreateUniTextObject(obj);
+                }
+            }
+                
+        }
+
+        private static void CreateUniTextObject(GameObject parent)
+        {
+            var go = new GameObject("UniText");
+            if (parent != null) 
+            {
+                go.transform.SetParent(parent.transform, false);
+                go.layer = parent.gameObject.layer;
+            }
+            var text = go.AddComponent<UniText>();
+            var font = text.GetType().GetField("fontStack", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (font != null)
+            {
+                font.SetValue(text, UniTextSettings.DefaultFontStack);
+            }
+            var appearance = text.GetType().GetField("appearance", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (appearance != null)
+            {
+                appearance.SetValue(text, UniTextSettings.DefaultAppearance);
+            }
+            Undo.RegisterCreatedObjectUndo(go, "CreateUniTextObject");
+            Selection.activeObject = go;
+        }
+    }
+}

--- a/Editor/UniTextEditorMenu.cs.meta
+++ b/Editor/UniTextEditorMenu.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3d3c4a114b7f43246afea8d833b42d95

--- a/Runtime/Core/Component/UniText.cs
+++ b/Runtime/Core/Component/UniText.cs
@@ -1290,7 +1290,14 @@ namespace LightSide
 
         private void ClearAllRenderers()
         {
-            for (var i = 0; i < subMeshRenderers.Count; i++) subMeshRenderers[i].renderer?.Clear();
+            for (var i = 0; i < subMeshRenderers.Count; i++)
+            {
+                if(subMeshRenderers[i].renderer != null)
+                {
+                    subMeshRenderers[i].renderer.Clear();
+                    DestroyImmediate(subMeshRenderers[i].renderer.gameObject);
+                }
+            }
         }
 
         private void ReleaseSubMeshStencilMaterials()


### PR DESCRIPTION
1.Add a UniText MenuItem to the GameObject Menu, Like TextMeshPro 

<img width="249" height="372" alt="image" src="https://github.com/user-attachments/assets/23cb3fc4-d12c-497b-935a-73b19797eef7" />

2.Fix a bug in submesh clearing

Unity null is not the same as C# null.

Runtime/Core/Component/UniText.cs

subMeshRenderers[i].renderer?.Clear();
Debug.Log(renderer == null); // True
Debug.Log((object)renderer == null); // False